### PR TITLE
Update vectorbender for QGIS 3

### DIFF
--- a/vectorbender.py
+++ b/vectorbender.py
@@ -179,7 +179,7 @@ class VectorBender:
                 if not geom.isMultipart():
                     # SINGLE PART POINT
                     p = geom.asPoint()
-                    newGeom = QgsGeometry.fromPoint( self.transformer.map(p) )
+                    newGeom = QgsGeometry.fromPointXY( self.transformer.map(p) )
 
                 else:
                     # MULTI PART POINT


### PR DESCRIPTION
Currently doesn't work for point vectors in QGIS 3.

Perhaps change .fromPoint() to .fromPointXY(), as is suggested here:
https://github.com/JonathanWillitts/common-qgis-2-to-3-plugin-fixes